### PR TITLE
fix: remove restricted media read permissions from Android manifest

### DIFF
--- a/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,6 @@
         <provider android:authorities="com.facebook.katana.provider.PlatformProvider" />
     </queries>
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_DOCUMENTS" />
     <application
         android:label="Warranty Manager Cloud"
         android:name="${applicationName}"

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -1001,10 +1001,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1302,10 +1302,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
Removed `READ_MEDIA_IMAGES`, `READ_MEDIA_DOCUMENTS` and `READ_EXTERNAL_STORAGE` permissions from `AndroidManifest.xml` in accordance with Google Play's Photo and Video Permissions policy. Since the app uses standard photo/file pickers for one-time selection, these broad storage access permissions are not required.

---
*PR created automatically by Jules for task [10255972121034278199](https://jules.google.com/task/10255972121034278199) started by @Aravin*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The app now requests fewer permissions, with storage and media access permissions removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->