### PR TITLE
Add App Update Prompt for Android

### DIFF
--- a/mobile_app/lib/screens/home/home.dart
+++ b/mobile_app/lib/screens/home/home.dart
@@ -89,8 +89,16 @@ class _HomeScreenState extends State<HomeScreen> {
     if (Platform.isAndroid) {
       try {
         final info = await InAppUpdate.checkForUpdate();
-        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
+        if (info.updateAvailability == UpdateAvailability.updateAvailable &&
+            info.immediateUpdateAllowed == true) {
           await InAppUpdate.performImmediateUpdate();
+        } else if (info.updateAvailability ==
+            UpdateAvailability.developerTriggeredUpdateInProgress) {
+          // Monitor install status instead of re-triggering update
+          debugPrint('Update in progress, current status: ${info.installStatus}');
+          InAppUpdate.installStatusStream.listen((status) {
+            debugPrint('Install status update: $status');
+          });
         }
       } catch (e) {
         debugPrint('Failed to check for updates: $e');

--- a/mobile_app/lib/screens/home/home.dart
+++ b/mobile_app/lib/screens/home/home.dart
@@ -16,6 +16,7 @@ import 'package:warranty_manager_cloud/screens/home/widgets/highlight_card.dart'
 import 'package:warranty_manager_cloud/screens/profile.dart';
 import 'package:warranty_manager_cloud/screens/settings_screen/settings_screen.dart';
 import 'package:in_app_review/in_app_review.dart';
+import 'package:in_app_update/in_app_update.dart';
 import 'package:warranty_manager_cloud/screens/static/about.dart';
 import 'package:warranty_manager_cloud/screens/static/privacy_policy.dart';
 import 'package:warranty_manager_cloud/screens/warranty_form.dart';
@@ -84,9 +85,23 @@ class _HomeScreenState extends State<HomeScreen> {
     });
   }
 
+  Future<void> checkForUpdate() async {
+    if (Platform.isAndroid) {
+      try {
+        final info = await InAppUpdate.checkForUpdate();
+        if (info.updateAvailability == UpdateAvailability.updateAvailable) {
+          await InAppUpdate.performImmediateUpdate();
+        }
+      } catch (e) {
+        debugPrint('Failed to check for updates: $e');
+      }
+    }
+  }
+
   @override
   void initState() {
     saveOnboardingSettings();
+    checkForUpdate();
     _initPackageInfo();
     super.initState();
 

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -933,6 +933,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  in_app_update:
+    dependency: "direct main"
+    description:
+      name: in_app_update
+      sha256: "9924a3efe592e1c0ec89dda3683b3cfec3d4cd02d908e6de00c24b759038ddb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   intl:
     dependency: "direct main"
     description:
@@ -1001,10 +1009,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1302,10 +1310,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   timezone:
     dependency: transitive
     description:

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   flutter_speed_dial: ^7.0.0
   file_picker: ^8.0.0
   pdfx: ^2.5.0
+  in_app_update: ^4.2.5
 
 dev_dependencies:
   flutter_test:

--- a/mobile_app/test/screens/home/check_for_update_test.dart
+++ b/mobile_app/test/screens/home/check_for_update_test.dart
@@ -1,0 +1,316 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_update/in_app_update.dart';
+
+/// Mirrors the logic added in home.dart `checkForUpdate()` with injectable
+/// dependencies so the branching logic can be unit-tested independently of the
+/// dart:io [Platform] check and static [InAppUpdate] methods.
+Future<void> performUpdateCheck({
+  required Future<AppUpdateInfo> Function() checkForUpdate,
+  required Future<void> Function() performImmediateUpdate,
+  required bool isAndroid,
+}) async {
+  if (isAndroid) {
+    try {
+      final info = await checkForUpdate();
+      if (info.updateAvailability == UpdateAvailability.updateAvailable) {
+        await performImmediateUpdate();
+      }
+    } catch (e) {
+      // Exceptions are silently caught, matching the debugPrint-only handler
+      // in the production implementation.
+    }
+  }
+}
+
+void main() {
+  group('checkForUpdate logic', () {
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// Builds an [AppUpdateInfo] with the given availability.
+    AppUpdateInfo _makeInfo(UpdateAvailability availability) {
+      return AppUpdateInfo(
+        updateAvailability: availability,
+        immediateUpdateAllowed: availability == UpdateAvailability.updateAvailable,
+        flexibleUpdateAllowed: false,
+        availableVersionCode: availability == UpdateAvailability.updateAvailable ? 999 : null,
+      );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Android platform – update available
+    // ---------------------------------------------------------------------------
+
+    test('calls performImmediateUpdate when update is available on Android',
+        () async {
+      bool immediateUpdateCalled = false;
+
+      await performUpdateCheck(
+        isAndroid: true,
+        checkForUpdate: () async => _makeInfo(UpdateAvailability.updateAvailable),
+        performImmediateUpdate: () async {
+          immediateUpdateCalled = true;
+        },
+      );
+
+      expect(immediateUpdateCalled, isTrue);
+    });
+
+    // ---------------------------------------------------------------------------
+    // Android platform – no update available
+    // ---------------------------------------------------------------------------
+
+    test('does not call performImmediateUpdate when no update is available',
+        () async {
+      bool immediateUpdateCalled = false;
+
+      await performUpdateCheck(
+        isAndroid: true,
+        checkForUpdate: () async =>
+            _makeInfo(UpdateAvailability.updateNotAvailable),
+        performImmediateUpdate: () async {
+          immediateUpdateCalled = true;
+        },
+      );
+
+      expect(immediateUpdateCalled, isFalse);
+    });
+
+    // ---------------------------------------------------------------------------
+    // Android platform – unknown availability
+    // ---------------------------------------------------------------------------
+
+    test('does not call performImmediateUpdate when availability is unknown',
+        () async {
+      bool immediateUpdateCalled = false;
+
+      await performUpdateCheck(
+        isAndroid: true,
+        checkForUpdate: () async => _makeInfo(UpdateAvailability.unknown),
+        performImmediateUpdate: () async {
+          immediateUpdateCalled = true;
+        },
+      );
+
+      expect(immediateUpdateCalled, isFalse);
+    });
+
+    // ---------------------------------------------------------------------------
+    // Android platform – checkForUpdate throws
+    // ---------------------------------------------------------------------------
+
+    test('silently catches exception thrown by checkForUpdate', () async {
+      bool immediateUpdateCalled = false;
+
+      await expectLater(
+        performUpdateCheck(
+          isAndroid: true,
+          checkForUpdate: () async => throw Exception('Play Store unavailable'),
+          performImmediateUpdate: () async {
+            immediateUpdateCalled = true;
+          },
+        ),
+        completes,
+      );
+
+      expect(immediateUpdateCalled, isFalse);
+    });
+
+    // ---------------------------------------------------------------------------
+    // Android platform – performImmediateUpdate throws
+    // ---------------------------------------------------------------------------
+
+    test('silently catches exception thrown by performImmediateUpdate',
+        () async {
+      await expectLater(
+        performUpdateCheck(
+          isAndroid: true,
+          checkForUpdate: () async =>
+              _makeInfo(UpdateAvailability.updateAvailable),
+          performImmediateUpdate: () async =>
+              throw Exception('User cancelled update'),
+        ),
+        completes,
+      );
+    });
+
+    // ---------------------------------------------------------------------------
+    // Non-Android platform
+    // ---------------------------------------------------------------------------
+
+    test('skips all update logic on non-Android platforms', () async {
+      bool checkCalled = false;
+      bool immediateUpdateCalled = false;
+
+      await performUpdateCheck(
+        isAndroid: false,
+        checkForUpdate: () async {
+          checkCalled = true;
+          return _makeInfo(UpdateAvailability.updateAvailable);
+        },
+        performImmediateUpdate: () async {
+          immediateUpdateCalled = true;
+        },
+      );
+
+      expect(checkCalled, isFalse);
+      expect(immediateUpdateCalled, isFalse);
+    });
+
+    // ---------------------------------------------------------------------------
+    // Regression: developer preview / unknown future availability value
+    // ---------------------------------------------------------------------------
+
+    test(
+        'regression: unrecognised UpdateAvailability value does not trigger update',
+        () async {
+      bool immediateUpdateCalled = false;
+
+      // developerTriggeredUpdateInProgress is a known variant that is NOT
+      // updateAvailable and must not trigger an immediate update flow.
+      await performUpdateCheck(
+        isAndroid: true,
+        checkForUpdate: () async => _makeInfo(
+          UpdateAvailability.developerTriggeredUpdateInProgress,
+        ),
+        performImmediateUpdate: () async {
+          immediateUpdateCalled = true;
+        },
+      );
+
+      expect(immediateUpdateCalled, isFalse);
+    });
+
+    // ---------------------------------------------------------------------------
+    // Boundary: checkForUpdate returns synchronously (no async gap)
+    // ---------------------------------------------------------------------------
+
+    test('handles synchronous-like Future completion without error', () async {
+      bool immediateUpdateCalled = false;
+
+      await performUpdateCheck(
+        isAndroid: true,
+        checkForUpdate: () => Future.value(
+          _makeInfo(UpdateAvailability.updateAvailable),
+        ),
+        performImmediateUpdate: () {
+          immediateUpdateCalled = true;
+          return Future.value();
+        },
+      );
+
+      expect(immediateUpdateCalled, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Method channel integration – in_app_update channel
+  // ---------------------------------------------------------------------------
+
+  group('InAppUpdate method channel behaviour', () {
+    const channel = MethodChannel('dev.fluttercommunity.plus/in_app_update');
+
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('channel returns update info map with updateAvailability field',
+        () async {
+      // Simulate what the native Android plugin returns for checkForUpdate.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'checkForUpdate') {
+          return {
+            'updateAvailability': 1, // 1 == updateAvailable in Play Core
+            'immediateUpdateAllowed': true,
+            'flexibleUpdateAllowed': false,
+          };
+        }
+        if (call.method == 'performImmediateUpdate') {
+          return 1; // ActivityResult.RESULT_OK
+        }
+        return null;
+      });
+
+      // We can't invoke InAppUpdate.checkForUpdate() directly on a non-Android
+      // host because the native resolver isn't present; we instead verify that
+      // the mock handler is wired correctly and responds as expected.
+      final completer = Completer<Map<Object?, Object?>?>();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        channel.name,
+        channel.codec.encodeMethodCall(const MethodCall('checkForUpdate')),
+        (data) {
+          final result = channel.codec.decodeEnvelope(data!);
+          completer.complete(result as Map<Object?, Object?>?);
+        },
+      );
+
+      final result = await completer.future;
+      expect(result, isNotNull);
+      expect(result!['updateAvailability'], equals(1));
+      expect(result['immediateUpdateAllowed'], isTrue);
+    });
+
+    test('channel handler for performImmediateUpdate returns success code',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'performImmediateUpdate') {
+          return 1; // RESULT_OK
+        }
+        return null;
+      });
+
+      final completer = Completer<Object?>();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        channel.name,
+        channel.codec
+            .encodeMethodCall(const MethodCall('performImmediateUpdate')),
+        (data) {
+          final result = channel.codec.decodeEnvelope(data!);
+          completer.complete(result);
+        },
+      );
+
+      final result = await completer.future;
+      expect(result, equals(1));
+    });
+
+    test('channel handler for performImmediateUpdate returns cancelled code',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'performImmediateUpdate') {
+          return 0; // RESULT_CANCELED
+        }
+        return null;
+      });
+
+      final completer = Completer<Object?>();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        channel.name,
+        channel.codec
+            .encodeMethodCall(const MethodCall('performImmediateUpdate')),
+        (data) {
+          final result = channel.codec.decodeEnvelope(data!);
+          completer.complete(result);
+        },
+      );
+
+      final result = await completer.future;
+      expect(result, equals(0));
+    });
+  });
+}


### PR DESCRIPTION
Added feature to prompt users on Android if a new app version is available upon loading the app. This uses the `in_app_update` package. It checks for update availability when the `HomeScreen` is initialized, and starts an immediate update if one is available.

---
*PR created automatically by Jules for task [16305157991254242814](https://jules.google.com/task/16305157991254242814) started by @Aravin*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now checks for Android in-app updates at startup.
  * When allowed, available updates are installed immediately.
  * Ongoing developer-triggered updates are tracked with status updates and logging.
  * Update check failures are caught and logged to avoid crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->