### PR TITLE
Fix OCR data mapping to FormBuilder fields

### DIFF
--- a/mobile_app/lib/screens/warranty_form.dart
+++ b/mobile_app/lib/screens/warranty_form.dart
@@ -167,7 +167,24 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderDateTimePicker(
                           name: "purchaseDate",
-                          initialValue: widget.initialData?['purchaseDate'],
+                          initialValue: () {
+                            final rawValue = widget.initialData?['purchaseDate'];
+                            if (rawValue == null) return null;
+                            if (rawValue is DateTime) return rawValue;
+                            if (rawValue is String) {
+                              final parsed = DateTime.tryParse(rawValue);
+                              if (parsed != null) return parsed;
+                              final milliseconds = int.tryParse(rawValue);
+                              if (milliseconds != null) {
+                                return DateTime.fromMillisecondsSinceEpoch(milliseconds);
+                              }
+                              return null;
+                            }
+                            if (rawValue is int) {
+                              return DateTime.fromMillisecondsSinceEpoch(rawValue);
+                            }
+                            return null;
+                          }(),
                           textInputAction: TextInputAction.next,
                           validator: FormBuilderValidators.compose(
                               [FormBuilderValidators.required()]),
@@ -184,7 +201,10 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderDropdown(
                           name: "warrantyPeriod",
-                          initialValue: widget.initialData?['warrantyPeriod'] ?? _product.warrantyPeriod,
+                          initialValue: () {
+                            final value = widget.initialData?['warrantyPeriod'] ?? _product.warrantyPeriod;
+                            return kWarrantyPeriods.contains(value) ? value : null;
+                          }(),
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.timer),
                             labelText: 'warranty_period'.tr(),
@@ -210,7 +230,10 @@ class _WarrantyFormState extends State<WarrantyForm> {
                             prefixIconColor: kPrimaryColor,
                             hintStyle: const TextStyle(color: Colors.grey),
                           ),
-                          initialValue: widget.initialData?['category']?.toString() ?? 'Other',
+                          initialValue: () {
+                            final value = widget.initialData?['category']?.toString() ?? 'Other';
+                            return categoryList.contains(value) ? value : null;
+                          }(),
                           items: categoryList
                               .map((category) => DropdownMenuItem(
                                   value: category, child: Text(category)))

--- a/mobile_app/lib/screens/warranty_form.dart
+++ b/mobile_app/lib/screens/warranty_form.dart
@@ -133,6 +133,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                       children: [
                         FormBuilderTextField(
                           name: 'name',
+                          initialValue: widget.initialData?['name']?.toString(),
                           validator: FormBuilderValidators.compose([
                             FormBuilderValidators.required(),
                             FormBuilderValidators.minLength(3),
@@ -149,6 +150,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderTextField(
                           name: 'company',
+                          initialValue: widget.initialData?['company']?.toString(),
                           textInputAction: TextInputAction.next,
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.branding_watermark),
@@ -165,6 +167,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderDateTimePicker(
                           name: "purchaseDate",
+                          initialValue: widget.initialData?['purchaseDate'],
                           textInputAction: TextInputAction.next,
                           validator: FormBuilderValidators.compose(
                               [FormBuilderValidators.required()]),
@@ -181,7 +184,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderDropdown(
                           name: "warrantyPeriod",
-                          initialValue: _product.warrantyPeriod,
+                          initialValue: widget.initialData?['warrantyPeriod'] ?? _product.warrantyPeriod,
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.timer),
                             labelText: 'warranty_period'.tr(),
@@ -207,7 +210,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                             prefixIconColor: kPrimaryColor,
                             hintStyle: const TextStyle(color: Colors.grey),
                           ),
-                          initialValue: 'Other',
+                          initialValue: widget.initialData?['category']?.toString() ?? 'Other',
                           items: categoryList
                               .map((category) => DropdownMenuItem(
                                   value: category, child: Text(category)))
@@ -223,6 +226,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                       children: [
                         FormBuilderTextField(
                           name: 'price',
+                          initialValue: widget.initialData?['price']?.toString(),
                           keyboardType: TextInputType.number,
                           textInputAction: TextInputAction.next,
                           validator: (value) {
@@ -243,6 +247,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderTextField(
                           name: 'purchasedAt',
+                          initialValue: widget.initialData?['purchasedAt']?.toString(),
                           textInputAction: TextInputAction.next,
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.add_location),
@@ -254,6 +259,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderTextField(
                           name: 'salesPerson',
+                          initialValue: widget.initialData?['salesPerson']?.toString(),
                           textInputAction: TextInputAction.next,
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.people),
@@ -265,6 +271,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderTextField(
                           name: 'phone',
+                          initialValue: widget.initialData?['phone']?.toString(),
                           keyboardType: TextInputType.number,
                           textInputAction: TextInputAction.next,
                           decoration: InputDecoration(
@@ -277,6 +284,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                         ),
                         FormBuilderTextField(
                           name: 'email',
+                          initialValue: widget.initialData?['email']?.toString(),
                           textInputAction: TextInputAction.next,
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.email),
@@ -290,6 +298,7 @@ class _WarrantyFormState extends State<WarrantyForm> {
                           maxLines: null,
                           keyboardType: TextInputType.multiline,
                           name: 'notes',
+                          initialValue: widget.initialData?['notes']?.toString(),
                           textInputAction: TextInputAction.done,
                           decoration: InputDecoration(
                             prefixIcon: const Icon(Icons.note_add),

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -1001,10 +1001,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1302,10 +1302,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   timezone:
     dependency: transitive
     description:

--- a/mobile_app/test/screens/warranty_forms_test.dart
+++ b/mobile_app/test/screens/warranty_forms_test.dart
@@ -104,10 +104,248 @@ void main() {
     });
   });
 
+  group('WarrantyForm initialData', () {
+    testWidgets('pre-populates all text fields from initialData', (
+      tester,
+    ) async {
+      final initialData = {
+        'name': 'Samsung TV',
+        'company': 'Samsung',
+        'purchaseDate': DateTime(2025, 1, 15),
+        'warrantyPeriod': '2 Year',
+        'category': 'Electronics',
+        'price': '45000',
+        'purchasedAt': 'Croma Store',
+        'salesPerson': 'John Doe',
+        'phone': '9876543210',
+        'email': 'support@samsung.com',
+        'notes': 'Keep the receipt safe',
+      };
+
+      await _pumpTestApp(tester, WarrantyForm(initialData: initialData));
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['name']?.value, 'Samsung TV');
+      expect(formState.fields['company']?.value, 'Samsung');
+      expect(formState.fields['purchaseDate']?.value, DateTime(2025, 1, 15));
+      expect(formState.fields['warrantyPeriod']?.value, '2 Year');
+      expect(formState.fields['category']?.value, 'Electronics');
+      expect(formState.fields['price']?.value, '45000');
+      expect(formState.fields['purchasedAt']?.value, 'Croma Store');
+      expect(formState.fields['salesPerson']?.value, 'John Doe');
+      expect(formState.fields['phone']?.value, '9876543210');
+      expect(formState.fields['email']?.value, 'support@samsung.com');
+      expect(formState.fields['notes']?.value, 'Keep the receipt safe');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('shows empty text fields and Other category when initialData is null', (
+      tester,
+    ) async {
+      await _pumpTestApp(tester, const WarrantyForm());
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['name']?.value, isNull);
+      expect(formState.fields['company']?.value, isNull);
+      expect(formState.fields['purchaseDate']?.value, isNull);
+      // warrantyPeriod falls back to Product().warrantyPeriod which is null
+      expect(formState.fields['warrantyPeriod']?.value, isNull);
+      // category falls back to 'Other'
+      expect(formState.fields['category']?.value, 'Other');
+      expect(formState.fields['price']?.value, isNull);
+      expect(formState.fields['purchasedAt']?.value, isNull);
+      expect(formState.fields['salesPerson']?.value, isNull);
+      expect(formState.fields['phone']?.value, isNull);
+      expect(formState.fields['email']?.value, isNull);
+      expect(formState.fields['notes']?.value, isNull);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('defaults category to Other when initialData has no category key', (
+      tester,
+    ) async {
+      // Provide initialData without a category entry
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(initialData: {'name': 'Mixer'}),
+      );
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['category']?.value, 'Other');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('uses initialData category over the Other default', (
+      tester,
+    ) async {
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(initialData: {'category': 'Appliances'}),
+      );
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['category']?.value, 'Appliances');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('uses initialData warrantyPeriod over Product default', (
+      tester,
+    ) async {
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(initialData: {'warrantyPeriod': '5 Year'}),
+      );
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['warrantyPeriod']?.value, '5 Year');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('converts non-string price to string for the price field', (
+      tester,
+    ) async {
+      // OCR may extract price as a number; the form should convert it
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(initialData: {'price': 12500}),
+      );
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['price']?.value, '12500');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('submits correct product when all initialData fields are present', (
+      tester,
+    ) async {
+      Product? submittedProduct;
+      final purchaseDate = DateTime(2024, 6, 20);
+
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(
+          initialData: {
+            'name': 'LG Refrigerator',
+            'company': 'LG',
+            'purchaseDate': purchaseDate,
+            'warrantyPeriod': '3 Year',
+            'category': 'Appliances',
+            'price': '35000',
+            'purchasedAt': 'Reliance Digital',
+            'salesPerson': 'Ramesh',
+            'phone': '9000000001',
+            'email': 'care@lg.com',
+            'notes': 'Extended warranty card inside box',
+          },
+          onSave: (product) async {
+            submittedProduct = product;
+            return 'new-product-id';
+          },
+          onSaveSuccess: (_, __) {},
+        ),
+      );
+
+      await tester.tap(_actionButtonFinder());
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(submittedProduct, isNotNull);
+      expect(submittedProduct!.name, 'LG Refrigerator');
+      expect(submittedProduct!.company, 'LG');
+      expect(submittedProduct!.purchaseDate, purchaseDate);
+      expect(submittedProduct!.warrantyPeriod, '3 Year');
+      expect(submittedProduct!.category, 'Appliances');
+      expect(submittedProduct!.price, 35000);
+      expect(submittedProduct!.purchasedAt, 'Reliance Digital');
+      expect(submittedProduct!.salesPerson, 'Ramesh');
+      expect(submittedProduct!.phone, '9000000001');
+      expect(submittedProduct!.email, 'care@lg.com');
+      expect(submittedProduct!.notes, 'Extended warranty card inside box');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('tolerates partial initialData with only required fields', (
+      tester,
+    ) async {
+      Product? submittedProduct;
+      final purchaseDate = DateTime(2025, 3, 10);
+
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(
+          initialData: {
+            'name': 'Bosch Mixer',
+            'company': 'Bosch',
+            'purchaseDate': purchaseDate,
+            'warrantyPeriod': '1 Year',
+          },
+          onSave: (product) async {
+            submittedProduct = product;
+            return 'partial-id';
+          },
+          onSaveSuccess: (_, __) {},
+        ),
+      );
+
+      await tester.tap(_actionButtonFinder());
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(submittedProduct, isNotNull);
+      expect(submittedProduct!.name, 'Bosch Mixer');
+      expect(submittedProduct!.company, 'Bosch');
+      expect(submittedProduct!.warrantyPeriod, '1 Year');
+      // Optional fields not in initialData should be null
+      expect(submittedProduct!.price, isNull);
+      expect(submittedProduct!.purchasedAt, isNull);
+      expect(submittedProduct!.salesPerson, isNull);
+      expect(submittedProduct!.phone, isNull);
+      expect(submittedProduct!.email, isNull);
+      expect(submittedProduct!.notes, isNull);
+      expect(tester.takeException(), isNull);
+    });
+
+    // Regression: verify the old hardcoded category default 'Other' still works
+    // now that it uses initialData?['category'] ?? 'Other'.
+    testWidgets('regression: category still defaults to Other when initialData is empty map', (
+      tester,
+    ) async {
+      await _pumpTestApp(
+        tester,
+        WarrantyForm(initialData: const {}),
+      );
+
+      final formState = tester.state<FormBuilderState>(
+        find.byWidgetPredicate((widget) => widget is FormBuilder),
+      );
+
+      expect(formState.fields['category']?.value, 'Other');
+      expect(tester.takeException(), isNull);
+    });
+  });
+
   group('WarrantyEditForm', () {
     testWidgets('updates preloaded values without optional images', (
       tester,
-    ) async {
+
       Product? updatedProduct;
 
       await _pumpTestApp(


### PR DESCRIPTION
This PR explicitly sets `initialValue` on each `FormBuilderTextField` in `WarrantyForm`. Previously, OCR data was successfully extracted and passed via the `initialData` map to `FormBuilder`, but fields in unmounted Stepper steps (like 'price', 'purchasedAt', etc.) failed to reflect these values when they eventually appeared on screen. Setting the parameter directly resolves this issue.

---
*PR created automatically by Jules for task [13691738603712558359](https://jules.google.com/task/13691738603712558359) started by @Aravin*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warranty form now pre-populates fields from existing data when editing (including contact, purchase, price, category and notes), with sensible defaults when values are missing.
* **Tests**
  * Added comprehensive tests validating pre-population, defaulting behavior, price value handling, and submission flows for full and partial initial data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->